### PR TITLE
Toplevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ be run (just by smashing `x`) or for less commonly used functionality.
       { "]h", function() require("notebook-navigator").move_cell("d") end },
       { "[h", function() require("notebook-navigator").move_cell("u") end },
       { "<S-CR>", function() require("notebook-navigator").run_and_move() end },
+      { "<C-CR>", function() require("notebook-navigator").run_toplevel() end },
     },
     dependencies = {
       "akinsho/toggleterm.nvim",
+      "nvim-treesitter/nvim-treesitter",
     },
     event = "VeryLazy",
     main = "notebook-navigator",

--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -1,5 +1,6 @@
 local commenter = require "notebook-navigator.commenters"
 local get_repl = require "notebook-navigator.repls"
+local gen_spec = require('mini.ai').gen_spec
 
 local M = {}
 
@@ -26,6 +27,71 @@ M.miniai_spec = function(opts, cell_marker)
   local to = { line = end_line, col = last_col }
 
   return { from = from, to = to }
+end
+
+-- Define specs for each type
+M.class_spec = gen_spec.treesitter({ a = '@class.outer', i = '@class.inner' })
+M.function_spec = gen_spec.treesitter({ a = '@function.outer', i = '@function.inner' })
+M.block_spec = gen_spec.treesitter({ a = '@block.outer', i = '@block.inner' })
+M.statement_spec = gen_spec.treesitter({ a = '@statement.outer', i = '@statement.inner' })
+
+-- Generic function to find the largest range containing the cursor
+M.find_largest_containing_range = function(ranges, cursor_line)
+  local best_match = nil
+  local best_size = -1
+  
+  for _, range in ipairs(ranges) do
+    -- Check if cursor is within this range (only need to check lines)
+    if cursor_line >= range.from.line and cursor_line <= range.to.line then
+      -- Calculate the size (number of lines)
+      local size = range.to.line - range.from.line + 1
+      
+      if size > best_size then
+        best_size = size
+        best_match = range
+      end
+    end
+  end
+  
+  return best_match
+end
+
+-- Find the largest text object containing the cursor
+M.find_toplevel = function(opts)
+  -- Get current cursor position
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local cursor_line = cursor[1]
+  
+  -- Try to find containing class first
+  local class_ranges = M.class_spec(opts)
+  local class_match = M.find_largest_containing_range(class_ranges, cursor_line)
+  if class_match then
+    return class_match
+  end
+  
+  -- If no class contains cursor, try functions
+  local function_ranges = M.function_spec(opts)
+  local function_match = M.find_largest_containing_range(function_ranges, cursor_line)
+  if function_match then
+    return function_match
+  end
+  
+  -- If no function contains cursor, try blocks
+  local block_ranges = M.block_spec(opts)
+  local block_match = M.find_largest_containing_range(block_ranges, cursor_line)
+  if block_match then
+    return block_match
+  end
+  
+  -- If no block contains cursor, try statements
+  local statement_ranges = M.statement_spec(opts)
+  local statement_match = M.find_largest_containing_range(statement_ranges, cursor_line)
+  if statement_match then
+    return statement_match
+  end
+  
+  -- Nothing found
+  return nil
 end
 
 M.move_cell = function(dir, cell_marker)
@@ -73,6 +139,26 @@ M.run_and_move = function(cell_marker, repl_provider, repl_args)
     -- and move to it
     M.move_cell("d", cell_marker)
   end
+end
+
+M.run_toplevel = function(repl_provider, repl_args)
+  repl_args = repl_args or nil
+  repl_provider = repl_provider or "auto"
+  local cell_object = M.find_toplevel("a")
+  if not cell_object then
+    return nil
+  end
+
+  -- protect ourselves against the case with no actual lines of code
+  local n_lines = cell_object.to.line - cell_object.from.line + 1
+  if n_lines < 1 then
+    return nil
+  end
+
+  local repl = get_repl(repl_provider)
+  repl(cell_object.from.line, cell_object.to.line, repl_args)
+  -- Move cursor to the end of the text object
+  vim.api.nvim_win_set_cursor(0, { cell_object.to.line, cell_object.to.col })
 end
 
 M.comment_cell = function(cell_marker)

--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -139,6 +139,9 @@ M.run_toplevel = function(repl_provider, repl_args)
   if next_range then
     -- Move cursor to the beginning of the next range
     vim.api.nvim_win_set_cursor(0, { next_range.from.line, next_range.from.col })
+  else
+    -- If there is no next range, move to the end of the current range
+    vim.api.nvim_win_set_cursor(0, { containing_range.to.line, containing_range.to.col })
   end
 end
 

--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -1,6 +1,7 @@
 local commenter = require "notebook-navigator.commenters"
 local get_repl = require "notebook-navigator.repls"
-local ts_queries = require('nvim-treesitter.query')
+local ts = vim.treesitter
+local ts_range = ts._range or require('nvim-treesitter-textobjects._range')
 
 local M = {}
 
@@ -30,7 +31,8 @@ M.miniai_spec = function(opts, cell_marker)
 end
 
 M.map_to_range = function(m)
-  local range = vim.treesitter.get_range(m.node, buf_id, m.metadata)
+  -- local range = vim.treesitter.get_range(m.node, buf_id, m.metadata)
+  local range = m
 
   -- map to 1-indexed lines and 0-indexed columns
   local from = { line = range[1] + 1, col = range[2] }
@@ -39,9 +41,167 @@ M.map_to_range = function(m)
   return { from = from, to = to }
 end
 
+---@param object table
+---@param path string[]
+---@param value table
+local function insert_to_path(object, path, value)
+  ---@type table<string, any|table<string, any>>
+  local curr_obj = object
+
+  for index = 1, (#path - 1) do
+    if curr_obj[path[index]] == nil then
+      curr_obj[path[index]] = {}
+    end
+
+    ---@type table<string, any|table<string, any>>
+    curr_obj = curr_obj[path[index]]
+  end
+
+  ---@type table<string, any|table<string, any>>
+  curr_obj[path[#path]] = value
+end
+
+---Memoize a function using hash_fn to hash the arguments.
+---@generic F: function
+---@param fn F
+---@param hash_fn fun(...): any
+---@return F
+local function memoize(fn, hash_fn)
+  local cache = setmetatable({}, { __mode = 'kv' }) ---@type table<any,any>
+
+  return function(...)
+    local key = hash_fn(...)
+    if cache[key] == nil then
+      local v = fn(...) ---@type any
+      cache[key] = v ~= nil and v or vim.NIL
+    end
+
+    local v = cache[key]
+    return v ~= vim.NIL and v or nil
+  end
+end
+
+--- Prepare matches for given query_group and parsed tree
+--- memoize by buffer tick and query group
+---
+---@param bufnr integer the buffer
+---@param query_group string the query file to use
+---@param root TSNode the root node
+---@param root_lang string the root node lang, if known
+---@return table[]
+local get_query_matches = memoize(function(bufnr, query_group, root, root_lang)
+  local query = ts.query.get(root_lang, query_group)
+  if not query then
+    return {}
+  end
+
+  local matches = {} ---@type table[]
+  local start_row, _, end_row, _ = root:range()
+  -- The end row is exclusive so we need to add 1 to it.
+  for pattern, match, metadata in query:iter_matches(root, bufnr, start_row, end_row + 1) do
+    if pattern then
+      local prepared_match = {}
+
+      -- Extract capture names from each match
+      for id, nodes in pairs(match) do
+        local query_name = query.captures[id] -- name of the capture in the query
+        if query_name ~= nil then
+          local path = vim.split(query_name, '%.')
+          if metadata[id] and metadata[id].range then
+            insert_to_path(prepared_match, path, ts_range.add_bytes(bufnr, metadata[id].range))
+          else
+            local srow, scol, sbyte, erow, ecol, ebyte = nodes[1]:range(true)
+            if #nodes > 1 then
+              local _, _, _, e_erow, e_ecol, e_ebyte = nodes[#nodes]:range(true)
+              erow = e_erow
+              ecol = e_ecol
+              ebyte = e_ebyte
+            end
+            insert_to_path(prepared_match, path, { srow, scol, sbyte, erow, ecol, ebyte })
+          end
+        end
+      end
+
+      if metadata.range and metadata.range[7] then
+        ---@cast metadata TSTextObjects.Metadata
+        local query_name = metadata.range[7]
+        local path = vim.split(query_name, '%.')
+        insert_to_path(prepared_match, path, {
+          metadata.range[1],
+          metadata.range[2],
+          metadata.range[3],
+          metadata.range[4],
+          metadata.range[5],
+          metadata.range[6],
+        })
+      end
+
+      matches[#matches + 1] = prepared_match
+    end
+  end
+  return matches
+end, function(bufnr, query_group, root)
+  return string.format('%d-%s-%s', bufnr, root:id(), query_group)
+end)
+
+---@param tbl table<string, any|table<string, any>> the table to access
+---@param path string the '.' separated path
+---@return any|nil result the value at path or nil
+local function get_at_path(tbl, path)
+  if path == '' then
+    return tbl
+  end
+
+  local segments = vim.split(path, '%.')
+  local result = tbl
+
+  for _, segment in ipairs(segments) do
+    if type(result) == 'table' then
+      ---@type any
+      result = result[segment]
+    end
+  end
+
+  return result
+end
+
+---@param bufnr integer
+---@param query_string string
+---@param query_group string
+---@return Range6[]
+local function get_capture_ranges_recursively(bufnr, query_string, query_group)
+  if query_string:sub(1, 1) ~= '@' then
+    error('Captures must start with "@"')
+    return {}
+  end
+  query_string = query_string:sub(2)
+
+  local parser = ts.get_parser(bufnr)
+  if not parser then
+    return {}
+  end
+  parser:parse(true)
+
+  local ranges = {} ---@type Range6[]
+  parser:for_each_tree(function(tree, lang_tree)
+    local tree_lang = lang_tree:lang()
+
+    local matches = get_query_matches(bufnr, query_group, tree:root(), tree_lang)
+    for _, match in pairs(matches) do
+      local found = get_at_path(match, query_string)
+      if found then
+        ---@cast found Range6
+        table.insert(ranges, found)
+      end
+    end
+  end)
+
+  return ranges
+end
+
 M.get_toplevels = function()
   local buf_id = vim.api.nvim_get_current_buf()
-  local matches = ts_queries.get_capture_matches_recursively(buf_id, '@toplevel', 'toplevels')
+  local matches = get_capture_ranges_recursively(buf_id, '@toplevel', 'toplevels')
   return vim.tbl_map(M.map_to_range, matches)
 end
 

--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -5,6 +5,19 @@ local ts_range = ts._range or require('nvim-treesitter-textobjects._range')
 
 local M = {}
 
+---@class OurPos
+---@inlinedoc
+---@field line integer 1-indexed line number
+---@field col integer 0-indexed column numberumn
+
+---@class OurRange
+---@inlinedoc
+---@field from OurPos start position
+---@field to OurPos end position
+
+---@param opts "i"|"a" whether to include the cell marker in the range or not
+---@param cell_marker string the cell marker to search for
+---@return OurRange
 M.miniai_spec = function(opts, cell_marker)
   local start_line = vim.fn.search("^" .. cell_marker, "bcnW")
 
@@ -30,6 +43,8 @@ M.miniai_spec = function(opts, cell_marker)
   return { from = from, to = to }
 end
 
+---@param m Range6
+---@return OurRange
 M.map_to_range = function(m)
   -- local range = vim.treesitter.get_range(m.node, buf_id, m.metadata)
   local range = m
@@ -123,7 +138,6 @@ local get_query_matches = memoize(function(bufnr, query_group, root, root_lang)
       end
 
       if metadata.range and metadata.range[7] then
-        ---@cast metadata TSTextObjects.Metadata
         local query_name = metadata.range[7]
         local path = vim.split(query_name, '%.')
         insert_to_path(prepared_match, path, {
@@ -146,7 +160,7 @@ end)
 
 ---@param tbl table<string, any|table<string, any>> the table to access
 ---@param path string the '.' separated path
----@return any|nil result the value at path or nil
+---@return any|nil # result the value at path or nil
 local function get_at_path(tbl, path)
   if path == '' then
     return tbl
@@ -199,20 +213,27 @@ local function get_capture_ranges_recursively(bufnr, query_string, query_group)
   return ranges
 end
 
+---@return OurRange[]
 M.get_toplevels = function()
   local buf_id = vim.api.nvim_get_current_buf()
   local matches = get_capture_ranges_recursively(buf_id, '@toplevel', 'toplevels')
   return vim.tbl_map(M.map_to_range, matches)
 end
 
+---@class CellObject
+---@inlinedoc
+---@field containing_range OurRange|nil the range of the toplevel containing the cursor, or nil if there is no such toplevel
+---@field next_range OurRange|nil the range of the next toplevel after the one containing the cursor, or nil if there is no such toplevel
+
 -- Find the toplevel containing the cursor
+---@return CellObject
 M.find_toplevel = function()
   -- Get all matched ranges for the toplevels
   local ranges = M.get_toplevels()
 
   -- Get current cursor position
   local cursor = vim.api.nvim_win_get_cursor(0)
-  local cursor_line = cursor[1]  -- the cursor line is 1-indexed in Neovim
+  local cursor_line = cursor[1] -- the cursor line is 1-indexed in Neovim
 
   local containing_range = nil
   local next_range = nil
@@ -222,15 +243,18 @@ M.find_toplevel = function()
       -- We need to return the range after the one containing the cursor
       next_range = range
       break
-    -- Check if cursor is within this range (only need to check lines)
+      -- Check if cursor is within this range (only need to check lines)
     elseif cursor_line >= range.from.line and cursor_line <= range.to.line then
       containing_range = range
     end
   end
 
-  return {containing_range = containing_range, next_range = next_range}
+  return { containing_range = containing_range, next_range = next_range }
 end
 
+---@param dir "d" | "u" direction to move the cell, either down or up
+---@param cell_marker string the cell marker to search for
+---@return "last" | "first" | nil # whether we moved to the last cell, first cell, or a normal cell
 M.move_cell = function(dir, cell_marker)
   local search_res
   local result
@@ -251,6 +275,9 @@ M.move_cell = function(dir, cell_marker)
   return result
 end
 
+---@param cell_marker string the cell marker to search for
+---@param repl_provider "iron"|"toggleterm"|"auto" the REPL provider to use
+---@param repl_args table|nil additional arguments to pass to the REPL provider, e.g. toggleterm id
 M.run_cell = function(cell_marker, repl_provider, repl_args)
   repl_args = repl_args or nil
   repl_provider = repl_provider or "auto"
@@ -266,6 +293,9 @@ M.run_cell = function(cell_marker, repl_provider, repl_args)
   repl(cell_object.from.line, cell_object.to.line, repl_args)
 end
 
+---@param cell_marker string the cell marker to search for
+---@param repl_provider "iron"|"toggleterm"|"auto" the REPL provider to use
+---@param repl_args table|nil additional arguments to pass to the REPL provider, e.g. toggleterm id
 M.run_and_move = function(cell_marker, repl_provider, repl_args)
   M.run_cell(cell_marker, repl_provider, repl_args)
   local is_last_cell = M.move_cell("d", cell_marker) == "last"
@@ -278,6 +308,8 @@ M.run_and_move = function(cell_marker, repl_provider, repl_args)
   end
 end
 
+---@param repl_provider "iron"|"toggleterm"|"auto" the REPL provider to use
+---@param repl_args table|nil additional arguments to pass to the REPL provider, e.g. toggleterm id
 M.run_toplevel = function(repl_provider, repl_args)
   repl_args = repl_args or nil
   repl_provider = repl_provider or "auto"
@@ -305,6 +337,7 @@ M.run_toplevel = function(repl_provider, repl_args)
   end
 end
 
+---@param cell_marker string the cell marker to search for
 M.comment_cell = function(cell_marker)
   local cell_object = M.miniai_spec("i", cell_marker)
 
@@ -316,6 +349,7 @@ M.comment_cell = function(cell_marker)
   commenter(cell_object)
 end
 
+---@param cell_marker string the cell marker to search for
 M.add_cell_before = function(cell_marker)
   local cell_object = M.miniai_spec("a", cell_marker)
 
@@ -331,6 +365,7 @@ M.add_cell_before = function(cell_marker)
   M.move_cell("u", cell_marker)
 end
 
+---@param cell_marker string the cell marker to search for
 M.add_cell_after = function(cell_marker)
   local cell_object = M.miniai_spec("a", cell_marker)
 

--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -277,7 +277,7 @@ end
 
 ---@param cell_marker string the cell marker to search for
 ---@param repl_provider "iron"|"toggleterm"|"auto" the REPL provider to use
----@param repl_args table|nil additional arguments to pass to the REPL provider, e.g. toggleterm id
+---@param repl_args table? additional arguments to pass to the REPL provider, e.g. toggleterm id
 M.run_cell = function(cell_marker, repl_provider, repl_args)
   repl_args = repl_args or nil
   repl_provider = repl_provider or "auto"
@@ -295,7 +295,7 @@ end
 
 ---@param cell_marker string the cell marker to search for
 ---@param repl_provider "iron"|"toggleterm"|"auto" the REPL provider to use
----@param repl_args table|nil additional arguments to pass to the REPL provider, e.g. toggleterm id
+---@param repl_args table? additional arguments to pass to the REPL provider, e.g. toggleterm id
 M.run_and_move = function(cell_marker, repl_provider, repl_args)
   M.run_cell(cell_marker, repl_provider, repl_args)
   local is_last_cell = M.move_cell("d", cell_marker) == "last"
@@ -309,7 +309,7 @@ M.run_and_move = function(cell_marker, repl_provider, repl_args)
 end
 
 ---@param repl_provider "iron"|"toggleterm"|"auto" the REPL provider to use
----@param repl_args table|nil additional arguments to pass to the REPL provider, e.g. toggleterm id
+---@param repl_args table? additional arguments to pass to the REPL provider, e.g. toggleterm id
 M.run_toplevel = function(repl_provider, repl_args)
   repl_args = repl_args or nil
   repl_provider = repl_provider or "auto"

--- a/lua/notebook-navigator/core.lua
+++ b/lua/notebook-navigator/core.lua
@@ -1,6 +1,6 @@
 local commenter = require "notebook-navigator.commenters"
 local get_repl = require "notebook-navigator.repls"
-local gen_spec = require('mini.ai').gen_spec
+local ts_queries = require('nvim-treesitter.query')
 
 local M = {}
 
@@ -29,69 +29,46 @@ M.miniai_spec = function(opts, cell_marker)
   return { from = from, to = to }
 end
 
--- Define specs for each type
-M.class_spec = gen_spec.treesitter({ a = '@class.outer', i = '@class.inner' })
-M.function_spec = gen_spec.treesitter({ a = '@function.outer', i = '@function.inner' })
-M.block_spec = gen_spec.treesitter({ a = '@block.outer', i = '@block.inner' })
-M.statement_spec = gen_spec.treesitter({ a = '@statement.outer', i = '@statement.inner' })
+M.map_to_range = function(m)
+  local range = vim.treesitter.get_range(m.node, buf_id, m.metadata)
 
--- Generic function to find the largest range containing the cursor
-M.find_largest_containing_range = function(ranges, cursor_line)
-  local best_match = nil
-  local best_size = -1
-  
-  for _, range in ipairs(ranges) do
-    -- Check if cursor is within this range (only need to check lines)
-    if cursor_line >= range.from.line and cursor_line <= range.to.line then
-      -- Calculate the size (number of lines)
-      local size = range.to.line - range.from.line + 1
-      
-      if size > best_size then
-        best_size = size
-        best_match = range
-      end
-    end
-  end
-  
-  return best_match
+  -- map to 1-indexed lines and 0-indexed columns
+  local from = { line = range[1] + 1, col = range[2] }
+  local to = { line = range[4] + 1, col = range[5] }
+
+  return { from = from, to = to }
 end
 
--- Find the largest text object containing the cursor
-M.find_toplevel = function(opts)
+M.get_toplevels = function()
+  local buf_id = vim.api.nvim_get_current_buf()
+  local matches = ts_queries.get_capture_matches_recursively(buf_id, '@toplevel', 'toplevels')
+  return vim.tbl_map(M.map_to_range, matches)
+end
+
+-- Find the toplevel containing the cursor
+M.find_toplevel = function()
+  -- Get all matched ranges for the toplevels
+  local ranges = M.get_toplevels()
+
   -- Get current cursor position
   local cursor = vim.api.nvim_win_get_cursor(0)
-  local cursor_line = cursor[1]
-  
-  -- Try to find containing class first
-  local class_ranges = M.class_spec(opts)
-  local class_match = M.find_largest_containing_range(class_ranges, cursor_line)
-  if class_match then
-    return class_match
+  local cursor_line = cursor[1]  -- the cursor line is 1-indexed in Neovim
+
+  local containing_range = nil
+  local next_range = nil
+
+  for _, range in ipairs(ranges) do
+    if containing_range then
+      -- We need to return the range after the one containing the cursor
+      next_range = range
+      break
+    -- Check if cursor is within this range (only need to check lines)
+    elseif cursor_line >= range.from.line and cursor_line <= range.to.line then
+      containing_range = range
+    end
   end
-  
-  -- If no class contains cursor, try functions
-  local function_ranges = M.function_spec(opts)
-  local function_match = M.find_largest_containing_range(function_ranges, cursor_line)
-  if function_match then
-    return function_match
-  end
-  
-  -- If no function contains cursor, try blocks
-  local block_ranges = M.block_spec(opts)
-  local block_match = M.find_largest_containing_range(block_ranges, cursor_line)
-  if block_match then
-    return block_match
-  end
-  
-  -- If no block contains cursor, try statements
-  local statement_ranges = M.statement_spec(opts)
-  local statement_match = M.find_largest_containing_range(statement_ranges, cursor_line)
-  if statement_match then
-    return statement_match
-  end
-  
-  -- Nothing found
-  return nil
+
+  return {containing_range = containing_range, next_range = next_range}
 end
 
 M.move_cell = function(dir, cell_marker)
@@ -144,21 +121,25 @@ end
 M.run_toplevel = function(repl_provider, repl_args)
   repl_args = repl_args or nil
   repl_provider = repl_provider or "auto"
-  local cell_object = M.find_toplevel("a")
-  if not cell_object then
+  local cell_object = M.find_toplevel()
+  local containing_range = cell_object.containing_range
+  local next_range = cell_object.next_range
+  if not containing_range then
     return nil
   end
 
   -- protect ourselves against the case with no actual lines of code
-  local n_lines = cell_object.to.line - cell_object.from.line + 1
+  local n_lines = containing_range.to.line - containing_range.from.line + 1
   if n_lines < 1 then
     return nil
   end
 
   local repl = get_repl(repl_provider)
-  repl(cell_object.from.line, cell_object.to.line, repl_args)
-  -- Move cursor to the end of the text object
-  vim.api.nvim_win_set_cursor(0, { cell_object.to.line, cell_object.to.col })
+  repl(containing_range.from.line, containing_range.to.line, repl_args)
+  if next_range then
+    -- Move cursor to the beginning of the next range
+    vim.api.nvim_win_set_cursor(0, { next_range.from.line, next_range.from.col })
+  end
 end
 
 M.comment_cell = function(cell_marker)

--- a/lua/notebook-navigator/init.lua
+++ b/lua/notebook-navigator/init.lua
@@ -84,6 +84,12 @@ M.run_and_move = function(repl_args)
   core.run_and_move(cell_marker(), M.config.repl_provider, repl_args)
 end
 
+--- Run the current toplevel object (class, function, module-level statement) under
+--- the cursor and jump to the end of it.
+M.run_toplevel = function(repl_args)
+  core.run_toplevel(M.config.repl_provider, repl_args)
+end
+
 --- Comment all the contents of the cell under the cursor
 ---
 --- The commenting functionality is supported by external plugins. Currently the

--- a/lua/notebook-navigator/init.lua
+++ b/lua/notebook-navigator/init.lua
@@ -39,6 +39,7 @@ local got_hydra, hydra = pcall(require, "hydra")
 local core = require "notebook-navigator.core"
 local utils = require "notebook-navigator.utils"
 
+---@return string
 local cell_marker = function()
   return utils.get_cell_marker(0, M.config.cell_markers)
 end
@@ -47,7 +48,7 @@ end
 
 --- Returns the boundaries of the current code cell.
 ---
----@param opts string Either "i" to select the inner lines of the cell or "a" for
+---@param opts "a" | "i" Either "i" to select the inner lines of the cell or "a" for
 ---   the outer cell.
 ---
 ---@return table Table with keys from/to indicating the start and end of the cell.
@@ -71,7 +72,7 @@ end
 
 --- Run the current cell under the cursor
 ---
----@param repl_args table|nil Optional config for the repl.
+---@param repl_args table? Optional config for the repl.
 M.run_cell = function(repl_args)
   core.run_cell(cell_marker(), M.config.repl_provider, repl_args)
 end
@@ -79,7 +80,7 @@ end
 --- Run the current cell under the cursor and jump to next cell. If no next cell
 --- is available it will create one like Jupyter notebooks.
 ---
----@param repl_args table|nil Optional config for the repl.
+---@param repl_args table? Optional config for the repl.
 M.run_and_move = function(repl_args)
   core.run_and_move(cell_marker(), M.config.repl_provider, repl_args)
 end
@@ -160,7 +161,7 @@ local function activate_hydra(config)
       M.add_cell_before,
       { desc = "Add cell after", nowait = true },
     },
-    { "q", nil, { exit = true, nowait = true, desc = "exit" } },
+    { "q",     nil, { exit = true, nowait = true, desc = "exit" } },
     { "<esc>", nil, { exit = true, nowait = true, desc = "exit" } },
   }
 

--- a/lua/notebook-navigator/init.lua
+++ b/lua/notebook-navigator/init.lua
@@ -63,7 +63,7 @@ end
 ---
 ---@param dir string Movement direction. "d" for down and "u" for up.
 ---
----@return string If movement failed return "first" or "last" if we where at the
+---@return string|nil # If movement failed return "first" or "last" if we where at the
 ---   first/last cell.
 M.move_cell = function(dir)
   return core.move_cell(dir, cell_marker())

--- a/lua/notebook-navigator/repls.lua
+++ b/lua/notebook-navigator/repls.lua
@@ -2,15 +2,18 @@ local repls = {}
 
 -- iron.nvim
 repls.iron = function(start_line, end_line, repl_args)
-  local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, 0)
+  local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
   require("iron.core").send(nil, lines)
 end
 
+---@param str string
+---@return boolean # whether the string is empty or contains only whitespace
 local function is_whitespace(str)
   return str:match("^%s*$") ~= nil
 end
 
 -- Function to remove leading and ending whitespace strings
+---@param lines string[]
 local function trim_whitespace_strings(lines)
   local start_idx, end_idx = 1, #lines
 
@@ -34,6 +37,10 @@ local function trim_whitespace_strings(lines)
 end
 
 -- toggleterm
+---@param start_line integer
+---@param end_line integer
+---@param repl_args table|nil
+---@return nil
 repls.toggleterm = function(start_line, end_line, repl_args)
   local id = 1
   if repl_args then
@@ -46,13 +53,13 @@ repls.toggleterm = function(start_line, end_line, repl_args)
   end
 
   local current_window = vim.api.nvim_get_current_win()
-  local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, 0)
+  local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
 
   if not lines or not next(lines) then
     return
   end
 
-  local cmd = string.char(15)  -- ^O (shift in)
+  local cmd = string.char(15) -- ^O (shift in)
 
   for _, line in ipairs(trim_whitespace_strings(lines)) do
     local l = line
@@ -60,7 +67,7 @@ repls.toggleterm = function(start_line, end_line, repl_args)
       cmd = cmd .. string.char(15) .. string.char(14)
       -- cmd = cmd .. string.char(14) .. string.char(15)
     else
-      cmd = cmd .. l .. string.char(10)  -- ^J (line feed)
+      cmd = cmd .. l .. string.char(10) -- ^J (line feed)
     end
   end
   -- cmd = cmd .. string.char(4)  -- ^D (end of transmission)
@@ -74,8 +81,9 @@ repls.toggleterm = function(start_line, end_line, repl_args)
 end
 
 -- no repl
-repls.no_repl = function(_) end
+repls.no_repl = function(_, _, _) end
 
+---@param repl_provider "iron"|"toggleterm"|"auto"
 local get_repl = function(repl_provider)
   local repl_providers = { "iron", "toggleterm" }
   if repl_provider == "auto" then

--- a/lua/notebook-navigator/repls.lua
+++ b/lua/notebook-navigator/repls.lua
@@ -84,6 +84,7 @@ end
 repls.no_repl = function(_, _, _) end
 
 ---@param repl_provider "iron"|"toggleterm"|"auto"
+---@return fun(start_line: integer, end_line: integer, repl_args: table?): nil
 local get_repl = function(repl_provider)
   local repl_providers = { "iron", "toggleterm" }
   if repl_provider == "auto" then

--- a/lua/notebook-navigator/utils.lua
+++ b/lua/notebook-navigator/utils.lua
@@ -1,5 +1,12 @@
 local utils = {}
 
+---Get cell marker for a given buffer and cell markers table.
+---The function checks the filetype of the buffer and returns the corresponding cell
+---marker from the cell markers table. If the filetype is empty or if there's no cell
+---marker defined for the filetype, it raises an error.
+---@param bufnr integer
+---@param cell_markers table<string, string> A table mapping filetypes to their corresponding cell markers.
+---@return string The cell marker for the buffer's filetype.
 utils.get_cell_marker = function(bufnr, cell_markers)
   local ft = vim.bo[bufnr].filetype
 

--- a/queries/python/toplevels.scm
+++ b/queries/python/toplevels.scm
@@ -1,0 +1,43 @@
+; inherit: python
+
+; Capture top-level function definitions
+(module
+  (function_definition) @toplevel)
+
+(module
+  (decorated_definition
+    (function_definition)) @toplevel)
+
+; Capture top-level class definitions
+(module
+  (class_definition) @toplevel)
+
+(module
+  (decorated_definition
+    (class_definition)) @toplevel)
+
+; Capture top-level imports
+(module
+  (import_statement) @toplevel)
+
+(module
+  (import_from_statement) @toplevel)
+
+; Capture other top-level statements (assignments, expressions, etc.)
+(module
+  (expression_statement) @toplevel)
+
+(module
+  (while_statement) @toplevel)
+
+(module
+  (for_statement) @toplevel)
+
+(module
+  (if_statement) @toplevel)
+
+(module
+  (match_statement) @toplevel)
+
+(module
+  (type_alias_statement) @toplevel)

--- a/queries/python/toplevels.scm
+++ b/queries/python/toplevels.scm
@@ -1,43 +1,20 @@
 ; inherit: python
 
-; Capture top-level function definitions
 (module
-  (function_definition) @toplevel)
-
-(module
-  (decorated_definition
-    (function_definition)) @toplevel)
-
-; Capture top-level class definitions
-(module
-  (class_definition) @toplevel)
-
-(module
-  (decorated_definition
-    (class_definition)) @toplevel)
-
-; Capture top-level imports
-(module
-  (import_statement) @toplevel)
-
-(module
-  (import_from_statement) @toplevel)
-
-; Capture other top-level statements (assignments, expressions, etc.)
-(module
-  (expression_statement) @toplevel)
-
-(module
-  (while_statement) @toplevel)
-
-(module
-  (for_statement) @toplevel)
-
-(module
-  (if_statement) @toplevel)
-
-(module
-  (match_statement) @toplevel)
-
-(module
-  (type_alias_statement) @toplevel)
+  [
+    (function_definition)
+    (class_definition)
+    (import_statement)
+    (import_from_statement)
+    (expression_statement)
+    (decorated_definition)
+    (if_statement)
+    (for_statement)
+    (while_statement)
+    (match_statement)
+    (try_statement)
+    (with_statement)
+    (raise_statement)
+    (assert_statement)
+    (type_alias_statement)
+  ] @toplevel)


### PR DESCRIPTION
TODO: I don't think we need the dependency on `mini.ai`. Just this code should be sufficient:

```lua
H.get_matched_ranges_plugin = function(captures)
  local ts_queries = require('nvim-treesitter.query')
  local buf_id = vim.api.nvim_get_current_buf()
  local matches = ts_queries.get_capture_matches_recursively(buf_id, captures, 'textobjects')
  local res = vim.tbl_map(function(m) return vim.treesitter.get_range(m.node, buf_id, m.metadata) end, matches)
  return res
end
```

source: https://github.com/echasnovski/mini.ai/blob/1cd4f021a05c29acd4ab511c0981da14217daf38/lua/mini/ai.lua#L1547-L1553

This code here indeed gives the range of the first function:

```
:lua vim.print(vim.treesitter.get_range(require('nvim-treesitter.query').get_capture_matches_recursively(1, "@function.outer", 'textobjects')[1].node, 1))
```

And instead of trying out class, function, block, statement in order, we can probably use a custom query. This is explained here: https://github.com/nvim-treesitter/nvim-treesitter-textobjects/tree/master?tab=readme-ov-file#overriding-or-extending-textobjects